### PR TITLE
Add localhost_aliases

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,4 @@
 default[:hosts_file][:path] = '/etc/hosts'
 default[:hosts_file][:define_self] = 'ip_address' # or 'loopback' or 'localhost_only'
+default[:hosts_file][:localhost_aliases] = []
 default[:hosts_file][:custom_entries] = {}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,10 +2,12 @@ case node[:hosts_file][:define_self]
 when 'ip_address'
   hosts_file_entry '127.0.0.1' do
     hostname 'localhost'
+    aliases node[:hosts_file][:localhost_aliases]
   end
   hosts_file_entry node.ipaddress do
     hostname node.fqdn
     aliases node.hostname
+    aliases node[:hosts_file][:localhost_aliases]
   end
 when 'localhost_only'
   hosts_file_entry '127.0.0.1' do


### PR DESCRIPTION
I try define aliases for 127.0.0.1 in this way:
```ruby
:hosts_file => {
  :custom_entries => {
    '127.0.0.1' => 'www.google.com'
  }
}
```

But this did't work, so I added `localhost_aliases` attribute. Now to add aliases for 127.0.0.1 need to do:
```ruby
:hosts_file => {
  :custom_entries => {
    :localhost_aliases => %w(www.google.com)
  }
}
```
