### PR TITLE
Reverse order of FQDN and hostname in hosts file for localhost

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,7 @@
 ---
 driver:
   name: vagrant
+  vm_hostname: default-hostname.example.com
 
 provisioner:
   name: chef_zero

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,8 +5,8 @@ node.default[:hosts_file][:hostname] = node[:hostname]
 
 # Always manage ourself
 hosts_file_entry '127.0.0.1' do
-  hostname node[:hosts_file][:hostname]
-  aliases [node[:hosts_file][:fqdn], 'localhost'].compact
+  hostname node[:hosts_file][:fqdn]
+  aliases [node[:hosts_file][:hostname], 'localhost'].compact
 end
 
 public_ip_hostname = case node[:hosts_file][:public_ips].to_s


### PR DESCRIPTION
In the current version, because the host is listed first and the FQDN second, there is a bug where on subsequent chef runs, the system keeps flipping between using the host or the FQDN as the proper hostname.

The system considers the first entry in the list to be the full hostname, and all subsequent entries to be aliases. In the first chef run, it lists the host part part of the name first (for example, "default-hostname"), and then lists the FQDN (for example default-hostname.example.com), and finally localhost. Due to the fact it uses this order, the hostname the system uses is just the host. The FQDN is aliased to that hostname, so even the command "hostname -f" returns just the host part of the name.

On subsequent runs, the chef-client detects the FQDN as just the hostname, and rewrites the line in the hosts file as follows:

```
           -127.0.0.1   default-hostname default-hostname.example.com localhost
           +127.0.0.1   default-hostname default-hostname localhost
```

Now that the FQDN isn't aliased to host name, the FQDN will detect properly, and the next chef-client run will produce the change:

```
           -127.0.0.1   default-hostname default-hostname localhost
           +127.0.0.1   default-hostname default-hostname.example.com localhost
```

Those two outputs will switch back and forth. This can be corrected by following the format listed in the hosts file man page (http://man7.org/linux/man-pages/man5/hosts.5.html), and listing the FQDN first.
