### PR TITLE
Allow public_ips attribute to be set to false to disable these entries

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,4 +3,4 @@ default[:hosts_file][:custom_entries] = {}
 
 default[:hosts_file][:fqdn] = node[:fqdn]
 default[:hosts_file][:hostname] = node[:hostname]
-default[:hosts_file][:public_ips] = 'hostname' # 'fqdn' or 'localhost'
+default[:hosts_file][:public_ips] = 'hostname' # 'fqdn' or 'localhost' or false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,21 +9,23 @@ hosts_file_entry '127.0.0.1' do
   aliases [node[:hosts_file][:hostname], 'localhost'].compact
 end
 
-public_ip_hostname = case node[:hosts_file][:public_ips].to_s
-when 'hostname'
-  node[:hosts_file][:hostname]
-when 'fqdn'
-  node[:hosts_file][:fqdn]
-else
-  'localhost'
-end
+if node[:hosts_file][:public_ips]
+  public_ip_hostname = case node[:hosts_file][:public_ips].to_s
+                       when 'hostname'
+                         node[:hosts_file][:hostname]
+                       when 'fqdn'
+                         node[:hosts_file][:fqdn]
+                       else
+                         'localhost'
+                       end
 
-node[:network][:interfaces].each do |name, info|
-  next unless info[:type] == 'eth'
-  info[:addresses].each do |address, a_info|
-    if(a_info[:family] == 'inet')
-      hosts_file_entry address do
-        hostname public_ip_hostname
+  node[:network][:interfaces].each do |name, info|
+    next unless info[:type] == 'eth'
+    info[:addresses].each do |address, a_info|
+      if(a_info[:family] == 'inet')
+        hosts_file_entry address do
+          hostname public_ip_hostname
+        end
       end
     end
   end


### PR DESCRIPTION
Although I've seen the hostname and FQDN applied to 127.0.0.1 or 127.0.1.1 by distributions before, I've never seen entries created for the local interfaces. I don't know what purpose this serves and setting them to localhost broke RabbitMQ here. I'd be inclined to remove this feature altogether but since everyone seems to have their own ideas about how the hosts file should look, let's just make it optional.

This diff is best viewed [without whitespace changes](18/files?w=1).