### PR TITLE
Allow run in test-kitchen with dokken 2.5.1 driver

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,6 +21,8 @@ if node[:hosts_file][:public_ips]
 
   node[:network][:interfaces].each do |name, info|
     next unless info[:type] == 'eth'
+    next if info[:addresses].nil?
+    
     info[:addresses].each do |address, a_info|
       if(a_info[:family] == 'inet')
         hosts_file_entry address do


### PR DESCRIPTION
While running cookbook in kitchen, the info[:addresses] becomes nil on second test run. I guess this is a problem of dokken, but here is a little workaround